### PR TITLE
Bug fix in MisfitParam::clear!()

### DIFF
--- a/src/InverseSolve/misfitParam.jl
+++ b/src/InverseSolve/misfitParam.jl
@@ -131,5 +131,6 @@ function clear!(P::MisfitParam;clearPFor::Bool=true, clearData::Bool=false,clear
 	end
 	if clearMesh2Mesh
 		P.gloc = getGlobalToLocal(1.0);
-	end		
+	end
+	return P;
 end


### PR DESCRIPTION
The return of clear! has to be the object itself. Otherwise the object is lost in Utils.clear!(RemoteRef)  Previously it was returning void.
