### PR TITLE
Added support for Pardiso solver and changed logic for checking MUMPS, Pardiso installs

### DIFF
--- a/src/InverseSolve/InverseSolve.jl
+++ b/src/InverseSolve/InverseSolve.jl
@@ -112,5 +112,6 @@ module InverseSolve
 	include("computeMisfit.jl")
 	include("computeGradMisfit.jl")
 	include("HessMatVec.jl")
+	include("iteratedTikhonov.jl")
 	
 end

--- a/src/InverseSolve/barrierGNCG.jl
+++ b/src/InverseSolve/barrierGNCG.jl
@@ -169,15 +169,14 @@ function  barrierGNCG(mc,pInv::InverseParam,pMis;rho = 10.0,epsilon = 0.1, indCr
 		
 		
 		dumpResults(mc,Dc,iter,pInv,pMis);
-		
-		if iter >= maxIter
-			break
-		elseif stepNorm < stepTol
+		if stepNorm < stepTol
 			outerFlag = 1
 			break
+		elseif iter >= maxIter
+			break
 		end
+		
 		# Evaluate gradient
-
 		tic()
 		if isempty(indCredit)
 			dF = computeGradMisfit(sig,Dc,pMis)

--- a/src/InverseSolve/iteratedTikhonov.jl
+++ b/src/InverseSolve/iteratedTikhonov.jl
@@ -1,0 +1,63 @@
+export iteratedTikhonov
+
+"""
+    mc,DC = iteratedTikhonov(mc,pInv::InverseParam,pMis,nAlpha,alphaFac,
+                            targetMisfit;indCredit=[],dumpResults::Function=dummy)
+    
+    Perform (Projected) Gauss-NewtonCG using iterated Tikhonov procedure to decrease
+    regularization parameter and update reference model after fixed number of GN iterations
+    set in pInv.
+    
+    Input:
+           mc::Vector         - Initial guess for model
+           pInv::InverseParam - parameter for inversion
+           pMis               - misfit terms
+           nAlpha             - maximum number of allowed regularization parameter (alpha) values
+           alphaFac           - alpha decrease factor. alpha_(i+1) = alpha_i/alphaFac
+           targetMisfit       - Termination criterion. iteratedTikhonov will exit 
+                                 -when data misfit < targetMisfit
+           indCredit          - indices of forward problems to work on
+           dumpResults        - A function pointer for saving the results throughout the iterations.
+                                 - We assume that dumpResults is dumpResults(mc,Dc,iter,pInv,pMis), 
+                                 - where mc is the recovered model, Dc is the predicted data. 
+                                 - If dumpResults is not given, nothing is done (dummy() is called).
+           
+    Output:
+           mc                 - final model
+           Dc                 - final computed data
+           tikhonovFlag       - Data misfit convergence flag
+           hist               - Iteration history. This is a vector. Each entry is
+                                 - a structure containing the projGNCG history for each
+                                 - alpha value.
+"""
+
+function iteratedTikhonov(mc,pInv::InverseParam,pMis,nAlpha,alphaFac,
+                          targetMisfit;indCredit=[],dumpResults::Function=dummy)
+
+  iter = 0
+  tikhonovFlag = -1
+  hist = projGNCGhis[]
+  Dc = []
+  while iter < nAlpha 
+    iter += 1
+    println("Starting projGNCG minimization with alpha $iter of $nAlpha")
+    println("alpha = $(pInv.alpha)")
+    mc,Dc,GNflag,GNhist = projGNCG(mc,pInv,pMis,dumpResults=dumpResults)
+    push!(hist,GNhist)
+    pInv.mref  = mc
+    pInv.alpha = pInv.alpha/alphaFac
+    GNiterIdx  = find(hist[end].F .> 0.0)
+    println(hist[end].F)
+    if minimum(hist[end].F[GNiterIdx]) <= targetMisfit
+      tikhonovFlag = 1
+      break
+    end
+  end
+  
+  if tikhonovFlag < 0 
+    println("iteratedTikhonov iterated maximum number of times, using $nAlpha alpha values but reached only a misfit of $(hist[end].F[end]).")
+  else
+    println("iteratedTikhonov exiting after reaching desired misfit")
+  end
+  return mc,Dc,tikhonovFlag,hist
+end

--- a/src/InverseSolve/projGNCG.jl
+++ b/src/InverseSolve/projGNCG.jl
@@ -221,10 +221,10 @@ function  projGNCG(mc,pInv::InverseParam,pMis;indCredit=[],dumpResults::Function
 		updateHis!(iter,His,Jc,F,Dc,R,alpha[1],countnz(Active),stepNorm,tMis,tReg)
 	
 		dumpResults(mc,Dc,iter,pInv,pMis);
-		if iter >= maxIter
-			break
-		elseif stepNorm < stepTol
+		if stepNorm < stepTol
 			outerFlag = 1
+			break
+		elseif iter >= maxIter
 			break
 		end
 		# Evaluate gradient

--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -6,15 +6,20 @@ module LinearSolvers
 	using KrylovMethods
 	
 	# check if MUMPS can be used
-	const minMUMPSversion = VersionNumber(0,0,1)
 	hasMUMPS=false
-	vMUMPS = VersionNumber(0,0,0)
 	try 
-		vMUMPS = Pkg.installed("MUMPS")
-		hasMUMPS = vMUMPS >= minMUMPSversion
+		using MUMPS
+		hasMUMPS = true
 	catch 
 	end
 	
+	# check if Pardiso is installed
+	hasPardiso = false
+	try
+		using Pardiso
+		hasPardiso = true
+	catch
+	end
 	
 	# check if ParSPMatVec is available
 	hasParSpMatVec = false
@@ -29,7 +34,7 @@ module LinearSolvers
 		using ParSpMatVec
 	end
 	
-	export solveLinearSystem
+	export solveLinearSystem!,solveLinearSystem
 	
 	solveLinearSystem(A,B,param::AbstractSolver,doTranspose::Int=0) = solveLinearSystem!(A,B,zeros(eltype(B),size(B)),param,doTranspose)
 
@@ -37,6 +42,7 @@ module LinearSolvers
 	# include("pcgWrapper.jl")
 	include("iterativeWrapper.jl")
 	include("blockcg.jl")
+	include("PardisoWrapper.jl")
 	# include("julia.jl")
 	
 	import jInv.Utils.clear!
@@ -44,5 +50,7 @@ module LinearSolvers
 	function clear!(M::AbstractSolver)
 		M.Ainv = []
 	end
+	
+	export clear!
 
 end # module LinearSolvers

--- a/src/LinearSolvers/PardisoWrapper.jl
+++ b/src/LinearSolvers/PardisoWrapper.jl
@@ -1,0 +1,112 @@
+export jInvPardisoSolver, getjInvPardisoSolver
+
+"""
+type jInvPardisoSolver
+
+Fields:
+
+	Ainv    - holds PardisoFactorization
+	doClear - flag to clear factorization
+	ooc     - flag for out-of-core option
+	sym     - 0=unsymmetric, 1=symm. pos def, 2=general symmetric
+	nFac    - number of factorizations performed
+	facTime - cumulative time for factorizations
+	nSolve  - number of solves
+	solveTime - cumnulative time for solves
+
+Example: 
+
+	Ainv = getjInvPardisoSolver()
+"""
+type jInvPardisoSolver<: AbstractSolver
+	Ainv
+	doClear::Int
+	ooc::Int
+	sym::Int
+	nFac::Int
+	facTime::Real
+	nSolve::Int
+	solveTime::Real
+	N::Int
+end
+
+# See if Pardiso is installed and include code for it.
+
+	
+if hasPardiso
+		
+	function getjInvPardisoSolver(Ainv=[],doClear=1,ooc=0,sym=11)
+		return jInvPardisoSolver(Ainv,doClear,ooc,sym,0,0.0,0,0.0,1)
+	end
+	
+	function solveLinearSystem!(A,B,X,param::jInvPardisoSolver,doTranspose=0)
+		if param.doClear == 1
+			clear!(param)
+		end
+	
+		if param.Ainv==[]
+			tic()
+			param.Ainv = MKLPardisoSolver()
+			param.N    = size(A,1)
+			param,Apard = pardisoSetup(param,A)
+			pardiso(param.Ainv,X,Apard,full(B))
+			param.facTime+=toq()
+			param.nFac+=1
+		end
+	
+		tic()
+		# Since pardiso requires CSR matrices as input,
+		# and Julia sparse matrices are CSC,
+		# we need to tell pardiso to solve transposed
+		# system when we want untransposed solve and
+		#vice versa
+		if doTranspose == 0
+		  set_iparm(param.Ainv, 12, 2)
+		else
+		  set_iparm(param.Ainv, 12, 0)
+		end
+		set_phase(param.Ainv,33)
+		pardiso(param.Ainv,X,A,full(B))
+		param.solveTime+=toq()
+		param.nSolve+=1
+	
+		return X, param		
+	end # function solveLinearSystem MKLPardisoSolver
+	
+	function pardisoSetup(param::jInvPardisoSolver,A::SparseMatrixCSC)
+			set_phase(param.Ainv,12) #Perform analysis and numerical fac.
+			set_mtype(param.Ainv,param.sym) #Set matrix type
+			pardisoinit(param.Ainv) #Initialize iparm
+			set_iparm(param.Ainv, 2, 3) #Use parallel metis ordering
+			if param.ooc != 0
+			  set_iparm(param.Ainv, 60, 2)
+			end
+			
+			# Pardiso only needs upper triangular part of
+			# symmetric matrices. We take lower triangular
+			# part due to CSC vs CSR conflict.
+			if param.sym in [2, 4, -2, -4]
+			  Apard = tril(A)
+			else 
+			  Apard = A
+			end
+			return param,Apard
+	end
+			
+	import jInv.Utils.clear!
+	function clear!(param::jInvPardisoSolver)
+		if param.Ainv==[]
+		        return
+		else
+			set_phase(param.Ainv,-1)
+			A = speye(2); x = ones(2);b = ones(2)
+			pardiso(param.Ainv,x,A,b)
+			param.Ainv = []
+		end
+	end
+	
+	function copySolver(Ainv::jInvPardisoSolver)
+		return jInvPardisoSolver(Ainv.Ainv,Ainv.doClear,Ainv.ooc,Ainv.sym,0,0.0,0,0.0,1);
+	end
+		
+end

--- a/src/LinearSolvers/mumpsWrapper.jl
+++ b/src/LinearSolvers/mumpsWrapper.jl
@@ -1,4 +1,4 @@
-export MUMPSsolver, getMUMPSsolver,solveLinearSystem,copySolver
+export MUMPSsolver, getMUMPSsolver,copySolver
 
 """
 type MUMPSsolver
@@ -33,7 +33,6 @@ end
 
 	
 if hasMUMPS
-	using MUMPS
 		
 	function getMUMPSsolver(Ainv=[],doClear=1,ooc=0,sym=0)
 		return MUMPSsolver(Ainv,doClear,ooc,sym,0,0.0,0,0.)

--- a/test/InverseSolve/testLeastSquares.jl
+++ b/test/InverseSolve/testLeastSquares.jl
@@ -82,3 +82,15 @@ pInv.maxIter = 5
 x2, = barrierGNCG(x0,pInv,pMisRefs)
 @test norm(x1-x2)/norm(x1) < 1e-12
 
+#Test iterated Tikhonov
+pInv.maxIter = 2
+pInv.alpha   = 100.
+nAlpha = 3
+alphaFac = 10.
+targetMisfit = 20.0
+x1,Dc,flag1,     = iteratedTikhonov(x0,pInv,pMis,nAlpha,alphaFac,targetMisfit)
+pInv.alpha = 100.
+pInv.mref  = x0
+x2,Dc,flag2,hist = iteratedTikhonov(x0,pInv,pMisRefs,nAlpha,alphaFac,targetMisfit)
+@test typeof(hist) <: Array{InverseSolve.projGNCGhis}
+@test norm(x1-x2)/norm(x1) < 1e-12


### PR DESCRIPTION
Hi Lars,
               I've made a couple of changes to the LinearSolvers.jl submodule. Have a look and merge if you're interested. I added support for Pardiso to LinearSolvers. Pardiso support relies on the [Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl) package. I also changed how LinearSolvers checks to see if MUMPS and Pardiso are installed. Pkg.installed() doesn't work on remote workers running on different nodes than the master process (see JuliaLang/julia#16222). Because of that limitation, LinearSolvers.jl throws an error when trying to load on multiple cluster nodes. My solution is to simply put the loading of the MUMPS and Pardiso modules in try/catch blocks:

```
hasMUMPS = false
try
  using MUMPS
  hasMUMPS = true
catch
end
```

The pull request also includes a small and very rudimentary wrapper of `projGNCG` for doing iteratedTikhonov to adjust the regularization parameter over the course of the inversion. This was a quick and dirty function I added for a specific project I was working on. If you're interested in merging the LinearSolvers changes but not adding the iteratedTikhonov wrapper let me know and I'll clean up the PR.

Patrick
