### PR TITLE
Fix clear! for jInvPardisoSolver with complex matrices

### DIFF
--- a/src/LinearSolvers/PardisoWrapper.jl
+++ b/src/LinearSolvers/PardisoWrapper.jl
@@ -101,7 +101,16 @@ if hasPardiso
 		        return
 		else
 			set_phase!(param.Ainv,-1)
-			A = speye(2); x = ones(2);b = ones(2)
+			# Real or complex matrix type
+			if param.sym in [1, 2, -2, 11]
+				A = speye(2)
+				x = ones(2)
+				b = ones(2)
+			else
+				A = speye(Complex128, 2)
+				x = ones(Complex128, 2)
+				b = ones(Complex128, 2)
+			end
 			pardiso(param.Ainv,x,A,b)
 			param.Ainv = []
 		end


### PR DESCRIPTION
clear!(param::jInvPardisoSolver) crashed if called to clear the
factorization of a complex matrix because a real matrix was passed
to the PARDISO library. The PARDISO library expects a matrix of
matching type for the clean-up phase.
