### PR TITLE
Fix bug in src/Mesh/getEdgeIntegralOfPolygonalChain.jl

### DIFF
--- a/src/Mesh/getEdgeIntegralOfPolygonalChain.jl
+++ b/src/Mesh/getEdgeIntegralOfPolygonalChain.jl
@@ -105,7 +105,7 @@ for ip = 1:np
       tz = Float64[]
     end
 
-    t  = sort(unique([0;tx;ty;tz;1]))
+    t  = sort(unique([-0.0;0.0;tx;ty;tz;1.0]))[2:end]
     nq = length(t) - 1
     tc = 0.5 * (t[1:nq] + t[2:nq+1])
 


### PR DESCRIPTION
getEdgeIntegralOfPolygonalChain crashes if line segments point in negative coordinate direction.

Julia's unique function treats the floating point numbers -0.0 and 0.0 as distinct numbers. This generates a line segment of length 0.0 which causes trouble later in the code. The fix eliminates the ambiguity between -0.0 and 0.0.