### PR TITLE
Redo of PR #34

### DIFF
--- a/src/Utils/sortpermFast.jl
+++ b/src/Utils/sortpermFast.jl
@@ -2,15 +2,58 @@
 export sortpermFast
 
 
-function sortpermFast(A)
+function sortpermFast(A::Vector)
    const n = length(A)
 
    ii = collect(1:n)
    B = copy(A)
    quicksort!(B,ii, 1,n)
 
-   return ii, B
-end # function mysortperm
+   return ii, B  #  B = A[ii]
+end # function sortpermFast
+
+#----------------------------------------------------
+
+function sortpermFast(A::Vector, D::Vector)
+   # Sort A and permute D according to A.
+   # For duplicate values in A, keep only values corresponding to
+   # the SMALLEST D.
+   const n = length(A)
+   if length(D) != n
+      error("Lengths of A and D must be the same.")
+   end
+
+   ii = collect(1:n)
+   quicksort!(A, ii, 1,n)
+
+   D = D[ii]
+   
+   if allunique(A)
+      return A, D
+   end
+   
+   idxkeep = trues(n)
+   
+   for j = 2 : n
+      for k = j-1 : -1 : 1
+         if A[j] != A[k]
+            break
+         end
+         
+         if D[j] < D[k]
+            idxkeep[k] = false
+         else
+            idxkeep[j] = false
+         end
+         
+      end  # k
+   end  # j
+
+   A = A[idxkeep]
+   D = D[idxkeep]
+
+   return A, D
+end # function sortpermFast
 
 #----------------------------------------------------
 

--- a/src/Utils/sparseUtils.jl
+++ b/src/Utils/sparseUtils.jl
@@ -1,4 +1,4 @@
-export sdiag
+export sdiag, spoutput
 
 import Base.kron
 import Base.SparseMatrixCSC
@@ -19,3 +19,34 @@ function kron(v1::SparseVector,v2::SparseVector)
   v = kron(SparseMatrixCSC(v1),SparseMatrixCSC(v2))
    return SparseVector(v.n,v.nzind,v.nzval)
 end
+
+#--------------------------------------------------------------------------
+
+function spoutput( filename::String,
+                   A::SparseMatrixCSC )
+# Output a 3 (or 4 for complex) column sparse matrix file.
+
+f = open(filename, "w")
+n = size(A,2)
+
+complexvalue = typeof(A.nzval[1]) == Complex128
+
+for ir = 1:n
+   j1 = A.colptr[ir]
+   j2 = A.colptr[ir+1] - 1
+
+   if complexvalue
+      for ic = j1:j2
+         println(f, A.rowval[ic], " ", ir, " ", real(A.nzval[ic]), " ", imag(A.nzval[ic]) )
+      end # ic
+   else
+      for ic = j1:j2
+         println(f, A.rowval[ic], " ", ir, " ", A.nzval[ic] )
+      end
+   end # ic
+
+end # ir
+
+close(f)
+return
+end # function spoutput

--- a/src/Utils/uniqueidx.jl
+++ b/src/Utils/uniqueidx.jl
@@ -1,48 +1,96 @@
+export uniqueidx, sortunique
 
-export uniqueidx
+"""
+function b,ii,jj = uniqueidx(a::Vector{Int64})
 
+b = sorted unique(a)
+ii, jj are permutations:
+a[ii] = b,  b[jj] = a
+"""
 function uniqueidx( a::Array{Int64,1} )
-    # b = sorted unique(a)
-    # ii, jj are permutations:
-    #    a[ii] = b,  b[jj] = a
+   
+   const n = length(a)
+   
+   #ii = sortperm(a)
+   #ii = sortperm(a,alg=MergeSort)
+   #b = a[ii]  # sorted array
 
-    const n = length(a)
+   ii,b = sortpermFast(a)
+   
 
-    #ii = sortperm(a)
-    #ii = sortperm(a,alg=MergeSort)
-    #b = a[ii]  # sorted array
-    ii,b = sortpermFast(a)
-
-    # jj = invperm(ii)  # inverse permutation
-    jj = Array(Int64,n)
-
-    nunique = n  # counter for # of unique values
-    p1 = 1  # pointer to the next unique element
-    jj[ii[1]] = 1
-
-    for i = 2:n
-        if b[p1] == b[i]
-            iip1 = ii[p1]
-            iii = ii[i]
-
-            jj[iip1] = p1
-            jj[iii]  = p1
-            idx = min( iip1, iii )
-            ii[p1] = idx
-
-            nunique = nunique - 1
-        else
-            p1 += 1
-            b[p1] = b[i]
-
-            iii = ii[i]
-            ii[p1] = iii
-            jj[iii] = p1
-        end
-    end  # i
-
-    deleteat!(b,  nunique+1:n)
-    deleteat!(ii, nunique+1:n)
-
-    return b, ii, jj
+  # jj = invperm(ii)  # inverse permutation
+   jj = Array(Int64,n)
+   
+   
+   nunique = n  # counter for # of unique values
+   p1 = 1  # pointer to the next unique element
+   jj[ii[1]] = 1
+   
+   for i = 2:n
+   
+      if b[p1] == b[i]
+         
+         iip1 = ii[p1]
+         iii = ii[i]
+         
+         jj[iip1] = p1
+         jj[iii]  = p1
+         idx = min( iip1, iii )
+         ii[p1] = idx
+         
+         nunique = nunique - 1
+      
+      else
+         p1 += 1
+         b[p1] = b[i]
+         
+         iii = ii[i]
+         ii[p1] = iii
+         jj[iii] = p1
+      end
+	
+   end  # i
+	
+	deleteat!(b,  nunique+1:n)
+	deleteat!(ii, nunique+1:n)
+	
+	return b, ii, jj
 end # function uniqueidx
+
+#-----------------------------------------------------
+
+"""
+function b = sortunique( a::Array{Int64,1} )
+
+b = sorted unique(a)
+same as uniqueidx but doesn't compute permutation
+vectors 
+"""
+function sortunique( a::Array{Int64,1} )
+
+   const n = length(a)
+   
+   ii,b = sortpermFast(a)
+   ii = []
+   
+   nunique = n  # counter for # of unique values
+   p1 = 1  # pointer to the next unique element
+   
+   for i = 2:n
+   
+      if b[p1] == b[i]
+         nunique -= 1
+      
+      else
+         p1 += 1
+         b[p1] = b[i]
+         
+      end
+   
+   end  # i
+   
+   deleteat!(b,  nunique+1:n)
+   #deleteat!(ii, nunique+1:n)
+   
+   return b
+end # function sortunique

--- a/src/Utils/variousUtils.jl
+++ b/src/Utils/variousUtils.jl
@@ -1,31 +1,41 @@
-export complex2real, real2complex
+export removeZeros, complex2real, real2complex
+
+#--------------------------------------------------------------------
+
+function removeZeros( A::Array )
+# Make array shorter by removing all zero values.
+A = A[A .!= 0]
+return A
+end # function removeZeros
+
+#---------------------------------------------------------------------
 
 function complex2real( a::Array{Complex128} )
-    # Convert from [a1 a2 ...] to [ ar1 ai1 ar2 ai2 ... ]
-    n = length(a)
-    b = Array{Float64}(n*2)
+# Convert from [a1 a2 ...] to [ ar1 ai1 ar2 ai2 ... ]
+n = length(a)
+b = Array{Float64}(n*2)
 
-    j = 1
-    for i = 1:n
-        b[j], b[j+1] = reim(a[i])
-        j += 2
-    end  # i
+j = 1
+for i = 1:n
+   b[j], b[j+1] = reim(a[i])
+   j += 2
+end  # i
 
-    return b   
+return b   
 end # function complex2real
 
 #---------------------------------------------------------------------
 
 function real2complex( b::Array{Float64} )
-    # Convert from [ br1 bi1 br2 bi2 ... ] to [b1 b2 ...]
-    n = length(b)
-    a = Array{Complex128}(div(n,2))
+# Convert from [ br1 bi1 br2 bi2 ... ] to [b1 b2 ...]
+n = length(b)
+a = Array{Complex128}(div(n,2))
 
-    j = 1
-    for i = 1:2:n
-        a[j] = complex( b[i], b[i+1] )
-        j += 1
-    end  # i
+j = 1
+for i = 1:2:n
+   a[j] = complex( b[i], b[i+1] )
+   j += 1
+end  # i
 
-    return a
+return a
 end  # function real2complex

--- a/test/Utils/testSortpermFast.jl
+++ b/test/Utils/testSortpermFast.jl
@@ -1,11 +1,11 @@
 using jInv.Utils
 using Base.Test
 
+v  = rand(1:200,54)
+vu = unique(v)
+w  = randn(100)
 
-v = unique(rand(1:200,54))
-w = randn(100)
-
-data = (v,w)
+data = (vu,w)
 println("testing sortpermFast")
 
 for k=1:length(data)
@@ -17,3 +17,21 @@ for k=1:length(data)
 	@test all(res1[1] .== res2)
 	@test all(res1[2] .== b2)
 end
+
+# Test two argument version
+vin  = copy(v)
+vuin = copy(vu)
+d    = rand(1:1000,54)
+du   = d[1:length(vu)]
+din  = copy(d)
+duin = copy(du)
+
+ii,vs  = sortpermFast(v)
+jj,vus = sortpermFast(vu)
+
+vin,din   = sortpermFast(vin,din)
+vuin,duin = sortpermFast(vuin,duin)
+
+@test vin == vuin == vus
+@test duin == du[jj] 
+@test length(din) == length(duin)

--- a/test/Utils/testUniqueIdx.jl
+++ b/test/Utils/testUniqueIdx.jl
@@ -8,10 +8,11 @@ ua = unique(a)
 println("testing uniqueidx")
 
 b,ii,jj = uniqueidx(a)
-
+b2      = sortunique(a)
 t1 = sort(ua)
 t2 = sortperm(ua)
 
 @test all(b .== t1)
 @test all(a[ii] .==ua[t2])
 @test all(b[jj].==a)
+@test b == b2


### PR DESCRIPTION
These changes are a subset of those proposed in #34. Changes to jInv/LinearSolvers iterative solver type and white-space changes from that PR were discarded. The rest of the changes from that PR remain. They are: 1) improvements to sortPermFast, including a new method. 2) Added spoutput function to write sparse matrices to text file. 3) Added sortunique function, which returns unique elements of input vector in sorted order. Same as uniqueidx function except it doesn't compute permutation vectors and is therefore more efficient. 4) Added removezeros utility function.

I propose that we close #34 and merge this one if everyone is happy with that. 