### PR TITLE
Allow for key word args in initRemoteChannel

### DIFF
--- a/src/Utils/initRemoteChannel.jl
+++ b/src/Utils/initRemoteChannel.jl
@@ -9,20 +9,18 @@ input:
        func::Union{Function,Type} -- function or type constructor
         pid::Int64 -- worker that will run f and store result
        args::varargs -- Arguments of f. These must be available on worker pid
+       kwargs::varargs -- Key word arguments of f. These must be available on worker pid
        
 output:
         ref::RemoteChannel -- Reusable reference to output of f.
        
 """
-function initRemoteChannel(func::Union{Function,Type},pid::Int64,args...)
-  #for val in args
-  #  remotecall_wait(identity,pid,val)
-  #end
-  return RemoteChannel(()->initChannel(func,args), pid)
+function initRemoteChannel(func::Union{Function,Type}, pid::Int64, args...; kwargs...)
+  return RemoteChannel(()->initChannel(func,args,kwargs), pid)
 end
 
-function initChannel(func::Union{Function,Type},args::Tuple)
-  obj = func(args...)
+function initChannel(func::Union{Function,Type},args::Tuple,kwargs::Array)
+  obj = func(args...; kwargs...)
   chan = Channel{typeof(obj)}(1)
   put!(chan,obj)
   return chan


### PR DESCRIPTION
Currently initRemoteChannel cannot handle functions that require keyword arguments.  This is a problem for the new getMaxwellTimeParam function that has optional keyword arguments.

I think this fixes the problem - it's backwards compatible and allows optional keywords to be added.