### PR TITLE
interpGlobalToLocal for multi parameter models

### DIFF
--- a/src/ForwardShare/interpLocalToGlobal.jl
+++ b/src/ForwardShare/interpLocalToGlobal.jl
@@ -70,6 +70,9 @@ end
 
 # Interpolate a vector x from the global mesh to the local mesh
 function interpGlobalToLocal(x::Vector{Float64}, P::SparseMatrixCSC)
+	n = div(length(x), size(P,1))
+	(length(x) == n * size(P,1)) || error("Incompatible input sizes")
+	x = reshape(x,(size(P,1),n))
 	if (eltype(P.nzval) == Int16) || (eltype(P.nzval) == Int8)
 		nzv = P.nzval
 		rv  = P.rowval
@@ -86,5 +89,5 @@ function interpGlobalToLocal(x::Vector{Float64}, P::SparseMatrixCSC)
 	else
 		y = P' * x
 	end
-	return y
+	return vec(y)
 end

--- a/src/ForwardShare/interpLocalToGlobal.jl
+++ b/src/ForwardShare/interpLocalToGlobal.jl
@@ -76,14 +76,16 @@ function interpGlobalToLocal(x::Vector{Float64}, P::SparseMatrixCSC)
 	if (eltype(P.nzval) == Int16) || (eltype(P.nzval) == Int8)
 		nzv = P.nzval
 		rv  = P.rowval
-		y   = zeros(P.n)
+		y   = zeros(P.n,n)
 		@inbounds begin
-			for i = 1 : P.n
-				tmp = 0.0
-				for j = P.colptr[i] : (P.colptr[i+1]-1)
-					tmp += x[rv[j]] / (1 << (-3 * nzv[j])) # = x[rv[j]] * 2 ^ (3 * nzv[j]); nzv[j] <= 0
+			for k = 1:n
+				for i = 1 : P.n
+					tmp = 0.0
+					for j = P.colptr[i] : (P.colptr[i+1]-1)
+						tmp += x[rv[j],k] / (1 << (-3 * nzv[j])) # = x[rv[j],k] * 2 ^ (3 * nzv[j]); nzv[j] <= 0
+					end
+					y[i,k] = tmp
 				end
-				y[i] = tmp
 			end
 		end
 	else


### PR DESCRIPTION
Expanded functionality of interpGlobalToLocal to allow for models that are integer multiples of the number of cells.  Useful for anisotropic modelling.

Co-Authored-By: Christoph Schwarzbach <cschwarzbach@users.noreply.github.com>