### PR TITLE
Add computeMisfit progress reports for problems with many pFors

### DIFF
--- a/src/InverseSolve/barrierGNCG.jl
+++ b/src/InverseSolve/barrierGNCG.jl
@@ -55,7 +55,7 @@ function  barrierGNCG(mc,pInv::InverseParam,pMis;rho = 10.0,epsilon = 0.1*(pInv.
 	if isempty(indCredit)
 		Dc,F,dF,d2F,pMis,tMis = computeMisfit(sig,pMis,true)
 	else
-		Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sig,pMis,true,indCredit)
+		Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sig,pMis,true,indCredit=indCredit)
 	end
 	dF = dsig'*dF
 
@@ -131,7 +131,7 @@ function  barrierGNCG(mc,pInv::InverseParam,pMis;rho = 10.0,epsilon = 0.1*(pInv.
 			if isempty(indCredit)
 				Dc,F,dF,d2F,pMis,tMis = computeMisfit(sigt,pMis,false)
 			else
-				Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sigt,false,indCredit)
+				Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sigt,false,indCredit=indCredit)
 			end
 			His.timeMisfit[iter+1,:]+=tMis
 

--- a/src/InverseSolve/computeMisfit.jl
+++ b/src/InverseSolve/computeMisfit.jl
@@ -92,8 +92,9 @@ end
 
 function computeMisfit(sigma,
 	pMisRefs::Array{RemoteChannel,1},
-	doDerivative::Bool=true,
-	indCredit=collect(1:length(pMisRefs)))
+	doDerivative::Bool=true;
+	indCredit::AbstractVector=1:length(pMisRefs),
+    printProgress::Bool=false)
 #=
 computeMisfit for multiple forward problems
 
@@ -102,6 +103,8 @@ This method runs in parallel (iff nworkers()> 1 )
 Note: ForwardProblems and Mesh-2-Mesh Interpolation are RemoteRefs
     (i.e. they are stored in memory of a particular worker).
 =#
+
+    n = 1
 
 	F   = 0.0
 	dF  = (doDerivative) ? zeros(length(sigma)) : []
@@ -135,6 +138,14 @@ Note: ForwardProblems and Mesh-2-Mesh Interpolation are RemoteRefs
 						Dc[idx],Fi,d2F[idx],tt = remotecall_fetch(computeMisfit,p,sigRef[p],pMisRefs[idx],dFiRef[p],doDerivative)
 						updateRes(Fi,idx)
 						updateTimes(tt)
+                        if printProgress && ((length(indDebit)/length(indCredit)) > n*0.1)
+                            if doDerivative
+                                println("Misfit and gradients computed for $(10*n)\% of forward problems")
+                            else
+                                println("Misfit and gradients computed for $(10*n)\% of forward problems")
+                            end
+                            n += 1
+                        end
 					end
 				end
 

--- a/src/InverseSolve/projGN.jl
+++ b/src/InverseSolve/projGN.jl
@@ -84,7 +84,7 @@ function  projGN(mc,pInv::InverseParam,pMis;indCredit=[],
 	if isempty(indCredit)
 		Dc,F,dF,d2F,pMis,tMis = computeMisfit(sig,pMis,true)
 	else
-		Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sig,pMis,true,indCredit)
+		Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sig,pMis,true,indCredit=indCredit)
 	end
 	dF = dsig'*dF
 	dumpResults(mc,Dc,0,pInv,pMis) # dump initial model and dpred0
@@ -151,16 +151,16 @@ function  projGN(mc,pInv::InverseParam,pMis;indCredit=[],
 			mt = mc + muLS*delm
 			mt[mt.<low]  = low[mt.<low]
 			mt[mt.>high] = high[mt.>high]
-			
-			
-			
-			
-			
-			
+
+
+
+
+
+
 			tic()
 			R,dR,d2R = computeRegularizer(pInv.regularizer,mt,pInv.mref,pInv.MInv,alpha)
 			His.timeReg[iter+1] += toq()
-			
+
 			if R!=Inf # to support barrier functions.
 				## evaluate function
 
@@ -168,18 +168,18 @@ function  projGN(mc,pInv::InverseParam,pMis;indCredit=[],
 				if isempty(indCredit)
 					Dc,F,dF,d2F,pMis,tMis = computeMisfit(sigt,pMis,false)
 				else
-					Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sigt,false,indCredit)
+					Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sigt,false,indCredit=indCredit)
 				end
 				His.timeMisfit[iter+1,:]+=tMis
 
-			
+
 				# objective function
 				Jt  = F  + R
 				if out>=2;
 					println(@sprintf( "   .%d\t%3.2e\t%3.2e\t\t\t%3.2e",
 						lsIter, F,       R,       Jt/J0))
 				end
-			
+
 				if Jt < Jc
 					break
 				end

--- a/src/InverseSolve/projSD.jl
+++ b/src/InverseSolve/projSD.jl
@@ -98,7 +98,7 @@ function  projSD(mc,pInv::InverseParam,pMis; proj=x->min.(max.(x,pInv.boundsLow)
 	if isempty(indCredit)
 		Dc,F,dF,d2F,pMis,tMis = computeMisfit(sig,pMis,true)
 	else
-		Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sig,pMis,true,indCredit)
+		Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sig,pMis,true,indCredit=indCredit)
 	end
 	dF = dsig'*dF
 
@@ -151,7 +151,7 @@ function  projSD(mc,pInv::InverseParam,pMis; proj=x->min.(max.(x,pInv.boundsLow)
 			if isempty(indCredit)
 				Dc,F,dF,d2F,pMis,tMis = computeMisfit(sigt,pMis,false)
 			else
-				Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sigt,false,indCredit)
+				Dc,F,dF,d2F,pMis,tMis,indDebit = computeMisfit(sigt,false,indCredit=indCredit)
 			end
 			His.timeMisfit[iter+1,:]+=tMis
 


### PR DESCRIPTION
Prints a message showing `computeMisfit`'s progress as a percentage of pFors completed. Prints after each 10% of pFors. Also makes `computeMisfit` input `indCredit` a keyword argument.